### PR TITLE
chore: Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "admin-menu-filter",
-	"version": "1.0.1",
+	"version": "1.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "admin-menu-filter",
-	"version": "1.0.2",
+	"version": "1.0.4",
 	"description": "Advanced phonetic admin menu filter for WordPress",
 	"main": "index.js",
 	"browserify": {


### PR DESCRIPTION
Composer can't seem to find version 1.0.2 of this package. I'm wondering if it's because I forgot to bump the package.json? Bumping to 1.0.4 since I think we'll need to create a new release in GH for this now.